### PR TITLE
Fix switching to the current channel

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -108,8 +108,6 @@ class ChatInterface(QMainWindow, Ui_MainWindow):
         if text:
             self.ui.lineEdit.setText("")
 
-            self.messages += f"You: {text}\n"
-
             discord_integration.send_message(text, self.channel)
 
             self.update_messages()
@@ -200,8 +198,9 @@ class ChatInterface(QMainWindow, Ui_MainWindow):
             buttons[i].clicked.connect((lambda channel=channel: lambda: self.switch_channel(channel))(channel))
 
     def switch_channel(self, _id):
-        self.channel = _id
-        self.ui.textBrowser.setText("No messages in this conversation yet!")
+        if _id != self.channel:
+            self.channel = _id
+            self.ui.textBrowser.setText("No messages in this conversation yet!")
 
     def get_servers(self):
         self.guilds = discord_integration.get_guilds()


### PR DESCRIPTION
When you click on the already current channel, the program would show "No messages in this conversation yet!" and get stuck there until you change to a different channel. This fixes that.