### PR TITLE
Only update the messages for the current channel ID

### DIFF
--- a/src/discord_integration.py
+++ b/src/discord_integration.py
@@ -61,7 +61,7 @@ if not validate_token():
         os.remove(platformdirs.user_config_dir("Qtcord") + "/discordauth.txt")
 
 
-def get_messages(channel_id: int, limit: int = 100) -> list:
+def get_messages(channel_id: int, limit: int = 100) -> dict:
     """
     Retrives messages from a specified channel.
 
@@ -70,7 +70,7 @@ def get_messages(channel_id: int, limit: int = 100) -> list:
         limit (int, optional): The maximum messages to request. Default is 100. May not go higher.
 
     Returns:
-        list: The messages from the channel.
+        dict: The channel ID as the only key, and a list with the messages from the channel as its value.
     """
 
     r = requests.get(
@@ -88,7 +88,7 @@ def get_messages(channel_id: int, limit: int = 100) -> list:
                 "id": 0,
             }
         )
-        return new_list
+        return {channel_id: new_list}
 
     for message in r.json():
         # TODO: You can get the author's profile picture ID from message["avatar"].
@@ -123,7 +123,7 @@ def get_messages(channel_id: int, limit: int = 100) -> list:
 
     # Reverse the list of messages
     new_list.reverse()
-    return new_list
+    return {channel_id: new_list}
 
 
 def send_message(msg, channel) -> None:

--- a/src/discord_worker.py
+++ b/src/discord_worker.py
@@ -3,7 +3,7 @@ from discord_integration import get_messages
 
 
 class WorkerSignals(QObject):
-    update = Signal(list)
+    update = Signal(dict)
 
 
 class Worker(QRunnable):

--- a/src/main.py
+++ b/src/main.py
@@ -117,7 +117,7 @@ class ChatInterface(QMainWindow, Ui_MainWindow):
         new_messages = ""
         last_timestamp = None
 
-        for message in messages:
+        for message in messages.get(self.channel, []):
             tags = """<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-weight:700;">"""
 
             timestamp = message["timestamp"]


### PR DESCRIPTION
Annotate the messages returned by discord_integration.get_messages() with its channel ID, and check this value matches the current channel ID before updating the view.

- [X] I agree to the [contributor agreements](https://github.com/mak448a/Qtcord/blob/main/CONTRIBUTING.md)
