### PR TITLE
Set the default text of the messages view as plain text instead of HTML

### DIFF
--- a/src/ui/main.ui
+++ b/src/ui/main.ui
@@ -55,15 +55,8 @@
           </property>
           <item row="0" column="0">
            <widget class="QTextBrowser" name="textBrowser">
-            <property name="html">
-             <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-hr { height: 1px; border-width: 0; }
-li.unchecked::marker { content: &quot;\2610&quot;; }
-li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;No channel selected!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <property name="plainText">
+             <string>No channel selected!</string>
             </property>
            </widget>
           </item>

--- a/src/ui/main_ui.py
+++ b/src/ui/main_ui.py
@@ -203,14 +203,7 @@ class Ui_MainWindow(object):
         self.actionLicenses.setText(QCoreApplication.translate("MainWindow", u"&Licenses", None))
         self.actionLogout.setText(QCoreApplication.translate("MainWindow", u"&Logout and Quit", None))
         self.actionReport_an_Issue.setText(QCoreApplication.translate("MainWindow", u"&Report an Issue", None))
-        self.textBrowser.setHtml(QCoreApplication.translate("MainWindow", u"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><meta charset=\"utf-8\" /><style type=\"text/css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"hr { height: 1px; border-width: 0; }\n"
-"li.unchecked::marker { content: \"\\2610\"; }\n"
-"li.checked::marker { content: \"\\2612\"; }\n"
-"</style></head><body style=\" font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;\">\n"
-"<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">No channel selected!</p></body></html>", None))
+        self.textBrowser.setPlainText(QCoreApplication.translate("MainWindow", u"No channel selected!", None))
         self.pushButton.setText(QCoreApplication.translate("MainWindow", u"Send", None))
         self.menuFile.setTitle(QCoreApplication.translate("MainWindow", u"&File", None))
         self.menuHelp.setTitle(QCoreApplication.translate("MainWindow", u"&Help", None))


### PR DESCRIPTION
It looks the same anyway.

- [X] I agree to the [contributor agreements](https://github.com/mak448a/Qtcord/blob/main/CONTRIBUTING.md)
