### PR TITLE
Add nicknames and simplify buttons code

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -187,7 +187,10 @@ class ChatInterface(QMainWindow, Ui_MainWindow):
 
         for friend in self.friends:
             user = friend["user"]
-            button = QPushButton(text=user["global_name"])
+
+            button = QPushButton(
+                text=friend["nickname"] if friend["nickname"] else user["global_name"]
+            )
 
             if os.path.exists(
                 os.path.join(
@@ -277,10 +280,7 @@ class ChatInterface(QMainWindow, Ui_MainWindow):
             button = QPushButton(text=channel["name"])
             self.ui.channels_scrollArea_contents.layout().addWidget(button)
 
-            channel = {
-                "id": channel["id"],
-                "name": channel['name'],
-            }
+            channel = {"id": channel["id"], "name": channel["name"]}
             # Oh my headache do not touch this code.
             # But if you do: https://stackoverflow.com/questions/19837486/lambda-in-a-loop
             button.clicked.connect(


### PR DESCRIPTION
* There's no need to add all button widgets to a container when they are never used again.
* When it's needed (the channel buttons), use a list as container, not a dict.
* Remove the get_channels() function as it seems to be unused.

- [X] I agree to the [contributor agreements](https://github.com/mak448a/Qtcord/blob/main/CONTRIBUTING.md)
