### PR TITLE
Rectify typo in application ID to fix Wayland window icon

### DIFF
--- a/helper_scripts/macos.spec
+++ b/helper_scripts/macos.spec
@@ -50,5 +50,5 @@ app = BUNDLE(
     coll,
     name='Qtcord-macOS.app',
     icon='../src/assets/icon.icns',
-    bundle_identifier='io.github.mak448a.Qtcord',
+    bundle_identifier='io.github.mak448a.QTCord',
 )

--- a/src/licensesui.py
+++ b/src/licensesui.py
@@ -13,6 +13,6 @@ class LicensesUI(QDialog, licenses_ui.Ui_LicensesDialog):
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
-    app.setDesktopFileName("io.github.mak448a.Qtcord")
+    app.setDesktopFileName("io.github.mak448a.QTCord")
     widget = LicensesUI()
     sys.exit(app.exec())

--- a/src/main.py
+++ b/src/main.py
@@ -335,7 +335,7 @@ def handle_no_internet() -> None:
         requests.get("https://discord.com")
     except requests.exceptions.ConnectionError:
         app = QApplication(sys.argv)
-        app.setDesktopFileName("io.github.mak448a.Qtcord")
+        app.setDesktopFileName("io.github.mak448a.QTCord")
         NoInternetUI().exec()
         sys.exit()
 
@@ -354,7 +354,7 @@ if __name__ == "__main__":
         os.makedirs(platformdirs.user_cache_dir("Qtcord"))
 
     app = QApplication(sys.argv)
-    app.setDesktopFileName("io.github.mak448a.Qtcord")
+    app.setDesktopFileName("io.github.mak448a.QTCord")
 
     # Add widget to switch between pages of UI
     switcher = QtWidgets.QStackedWidget()

--- a/src/no_internet.py
+++ b/src/no_internet.py
@@ -13,6 +13,6 @@ class NoInternetUI(QDialog, Ui_NoInternet):
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
-    app.setDesktopFileName("io.github.mak448a.Qtcord")
+    app.setDesktopFileName("io.github.mak448a.QTCord")
     widget = NoInternetUI()
     sys.exit(app.exec())

--- a/src/ui/no_internet.py
+++ b/src/ui/no_internet.py
@@ -23,7 +23,7 @@ class Ui_NoInternet(object):
         if not NoInternet.objectName():
             NoInternet.setObjectName(u"NoInternet")
         NoInternet.resize(400, 300)
-        icon = QIcon(QIcon.fromTheme(u"io.github.mak448a.Qtcord"))
+        icon = QIcon(QIcon.fromTheme(u"io.github.mak448a.QTCord"))
         NoInternet.setWindowIcon(icon)
         self.gridLayout = QGridLayout(NoInternet)
         self.gridLayout.setObjectName(u"gridLayout")

--- a/src/ui/no_internet.ui
+++ b/src/ui/no_internet.ui
@@ -14,7 +14,7 @@
    <string>Qtcord</string>
   </property>
   <property name="windowIcon">
-   <iconset theme="io.github.mak448a.Qtcord"/>
+   <iconset theme="io.github.mak448a.QTCord"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">


### PR DESCRIPTION
- [X] I agree to the [contributor agreements](https://github.com/mak448a/Qtcord/blob/main/CONTRIBUTING.md)

The actual application ID is `io.github.mak448a.QTCord`, however `io.github.mak448a.Qtcord` is used in some places including `setDesktopFileName()` which makes the window icon under Wayland fallback to the generic one.

![image](https://github.com/user-attachments/assets/fee4c75b-c163-4b8b-ba2c-f7affd1622c1)
