### PR TITLE
Update Discord API base to v10

### DIFF
--- a/src/discord_integration.py
+++ b/src/discord_integration.py
@@ -13,7 +13,7 @@ from discord_objects import (
 from discord_exceptions import ChannelAccessError, InvalidResponseError
 
 
-api_base = "https://discord.com/api/v9"
+api_base = "https://discord.com/api/v10"
 auth = ""  # Will be overridden when load_token is called
 headers = {
     "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) discord/0.0.63 Chrome/124.0.6367.243 Electron/30.2.0 Safari/537.36"


### PR DESCRIPTION
# Update Discord API version to v10

## Description
This PR updates the base Discord API URL to use version 10 (`api/v10`) instead of the older version 9 (`api/v9`), in accordance with the latest Discord developer documentation.

## Changes Made
* Modified `api_base` variable in `src/discord_integration.py` from `https://discord.com/api/v9` to `https://discord.com/api/v10`.

## Related Issues
* Closes #91

## Testing
Please ensure that basic API calls still succeed with the new API version and monitor for any deprecation warnings or breaking changes introduced in v10 that might affect the current integration.

- [x] I agree to the [contributor agreements](https://github.com/mak448a/Qtcord/blob/main/CONTRIBUTING.md)
