### PR TITLE
fix: differentiate call/image/file/sticker indicators for non-text messages

### DIFF
--- a/src/discord_objects.py
+++ b/src/discord_objects.py
@@ -129,10 +129,7 @@ class DiscordMessage:
             if message.get("call"):
                 content = "[(call)]"
             elif message.get("attachments"):
-                has_image = any(
-                    att.get("content_type", "").startswith("image/")
-                    for att in message["attachments"]
-                )
+                has_image = any(att.get("content_type", "").startswith("image/") for att in message["attachments"])
                 content = "[(image)]" if has_image else "[(file)]"
             elif message.get("sticker_items"):
                 content = "[(sticker)]"

--- a/src/discord_objects.py
+++ b/src/discord_objects.py
@@ -125,9 +125,19 @@ class DiscordMessage:
         # content = message["content"]
         # if content: ...
 
-        # TODO: WORK ON THIS. Make a difference between images and other stuff.
         if not (content := message["content"]):
-            content = "[(call/image/other)]"
+            if message.get("call"):
+                content = "[(call)]"
+            elif message.get("attachments"):
+                has_image = any(
+                    att.get("content_type", "").startswith("image/")
+                    for att in message["attachments"]
+                )
+                content = "[(image)]" if has_image else "[(file)]"
+            elif message.get("sticker_items"):
+                content = "[(sticker)]"
+            else:
+                content = "[(other)]"
 
         # For some reason, messages can use two, slightly different, timestamp formats.
         time_str = message["timestamp"]


### PR DESCRIPTION
Fixes #82

When a message has no text content, the previous code always displayed `[(call/image/other)]`. This change checks the actual message payload to determine the correct indicator:

- `[(call)]` — voice/video call messages
- `[(image)]` — messages with image attachments
- `[(file)]` — messages with non-image file attachments
- `[(sticker)]` — sticker messages
- `[(other)]` — fallback for anything else

Based on Discord API message object fields (`call`, `attachments` with `content_type`, `sticker_items`).